### PR TITLE
Fix/remove soliditysha3 dep

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015", "stage-2", "stage-3"]
+  "presets": ["env", "stage-2", "stage-3"]
 }

--- a/lib/tx_relay_signer.js
+++ b/lib/tx_relay_signer.js
@@ -1,13 +1,13 @@
 var Transaction = require('ethereumjs-tx');
 var UportIdentity = require('uport-identity')
 var util = require("ethereumjs-util");
-var Web3.utils = require('web3-utils')
+var Web3Utils = require('web3-utils')
 var leftPad = require('left-pad')
 var txutils = require('./txutils');
 
 var version = UportIdentity.TxRelay.latestVersion
 var txRelayAbi = UportIdentity.TxRelay[version].abi;
-var solsha3 = Web3.utils.soliditySha3
+var solsha3 = Web3Utils.soliditySha3
 
 var TxRelaySigner = function(keypair, txRelayAddress, txSenderAddress, whitelistOwner) {
   this.keypair = keypair;

--- a/lib/tx_relay_signer.js
+++ b/lib/tx_relay_signer.js
@@ -1,12 +1,13 @@
 var Transaction = require('ethereumjs-tx');
 var UportIdentity = require('uport-identity')
 var util = require("ethereumjs-util");
-var solsha3 = require('solidity-sha3').default
+var Web3.utils = require('web3-utils')
 var leftPad = require('left-pad')
 var txutils = require('./txutils');
 
 var version = UportIdentity.TxRelay.latestVersion
 var txRelayAbi = UportIdentity.TxRelay[version].abi;
+var solsha3 = Web3.utils.soliditySha3
 
 var TxRelaySigner = function(keypair, txRelayAddress, txSenderAddress, whitelistOwner) {
   this.keypair = keypair;

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "rlp": "^2.0.0",
     "scrypt-async": "^1.3.0",
     "secp256k1": "^3.2.0",
-    "solidity-sha3": "^0.4.1",
     "tweetnacl": "0.14.3",
     "tweetnacl-util": "^0.13.3",
     "uport-identity": "^2.0.0",
@@ -76,7 +75,7 @@
   },
   "devDependencies": {
     "async": "^1.4.2",
-    "babel-preset-es2015": "^6.16.0",
+    "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-2": "^6.24.1",
     "babel-preset-stage-3": "^6.24.1",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "scrypt-async": "^1.3.0",
     "secp256k1": "^3.2.0",
     "tweetnacl": "0.14.3",
+    "web3-utils": "1.0.0-beta.34",
     "tweetnacl-util": "^0.13.3",
     "uport-identity": "^2.0.0",
     "web3": "^0.19.1"


### PR DESCRIPTION
I've removed the dependency on soliditysha3, which has been implemented in web3js, in the subpackage web3-utils, as well as moving t babel-preset-env to replace babel-preset-es2015, as suggested by the babel team. 