### PR TITLE
Support function overloading

### DIFF
--- a/lib/txutils.js
+++ b/lib/txutils.js
@@ -31,10 +31,12 @@ function _decodeFunctionTxData(data, types) {
   return coder.decodeParams(types, bytes);
 }
 
-function _getTypesFromAbi(abi, functionName) {
+function _getTypesFromAbi(abi, functionName, argsLength) {
 
   function matchesFunctionName(json) {
-    return (json.name === functionName && json.type === 'function');
+    var match = (json.name === functionName && json.type === 'function');
+    if (!match || argsLength === undefined) return match;
+    return (json.inputs.length === argsLength);
   }
 
   function getTypes(json) {
@@ -49,7 +51,7 @@ function _getTypesFromAbi(abi, functionName) {
 function functionTx(abi, functionName, args, txObject) {
   // txObject contains gasPrice, gasLimit, nonce, to, value
 
-  var types = _getTypesFromAbi(abi, functionName);
+  var types = _getTypesFromAbi(abi, functionName, args.length);
   var txData = _encodeFunctionTxData(functionName, types, args);
 
   var txObjectCopy = {};


### PR DESCRIPTION
Hi, this makes `txutils.functionTx` work with `abi` which has multiple methods of the same name with different implementations, such as `transfer(address, uint)` and `transfer(address, uint, bytes)` in ERC223.

For now, it always select the first of them..
